### PR TITLE
add rudimentary looping to scan_*_contigs; fix get_spike_depth

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: spiky
 Type: Package
 Title: Spike-in calibration for cell-free MeDIP
 Description: spiky implements methods and model generation for cfMeDIP (cell-free methylated DNA immunoprecipitation) with spike-in controls. CfMeDIP is an enrichment protocol which avoids destructive conversion of scarce template, making it ideal as a "liquid biopsy," but creating certain challenges in comparing results across specimens, subjects, and experiments. The use of synthetic spike-in standard oligos allows diagnostics performed with cfMeDIP to quantitatively compare samples across subjects, experiments, and time points in both relative and absolute terms.
-Version: 0.99.998
-Date: 2021-05-13
+Version: 0.99.999
+Date: 2021-05-18
 Authors@R: c(person("Samantha", "Wilson", role=c("aut")), 
              person("Jordan", "Veldboom", role=c("ctb")),
              person("Lauren", "Harmon", role=c("aut")),

--- a/R/covg_to_df.R
+++ b/R/covg_to_df.R
@@ -23,7 +23,11 @@ covg_to_df <- function(res, spike, meth=TRUE, ID=NULL) {
     ID <- paste(toupper(sample(c(letters, 0:9), 4)), collapse="")
   }
 
-  spikes <- res$spikes
+  if ("spikes" %in% names(res)) {
+    spikes <- res$spikes
+  } else {
+    spikes <- res
+  }
   if (!"methylated" %in% names(mcols(spikes))) {
     if (is.null(spike)) {
       message("You need to provide a `spike` database to proceed.")

--- a/R/get_spike_depth.R
+++ b/R/get_spike_depth.R
@@ -1,7 +1,7 @@
 #' get the (max, median, or mean) coverage for spike-in contigs from a BAM/CRAM
 #'
 #' @param covg      the coverage RleList
-#' @param spike_gr  the spike-in GRanges
+#' @param spike_gr  the spike-in GRanges (default: figure out from seqinfo)
 #' @param spike     information about the spikes (default: load `spike`)
 #' @param how       how to summarize the per-spike coverage (max)
 #'
@@ -23,11 +23,21 @@
 #' get_spike_depth(covg, spike_gr=mgr, spike=spike)
 #'
 #' @export
-get_spike_depth <- function(covg, spike_gr, spike, how=c("max", "mean")) {
+get_spike_depth <- function(covg, spike_gr=NULL, spike=NULL, 
+                            how=c("max", "mean")) {
 
   how <- match.fun(match.arg(how))
   if (!is(spike, "DFrame")) stop("Please provide a spike database")
   cols <- colnames(spike)[-1]
+
+  # as with scan_spike_contigs()
+  if (is.null(spike_gr)) {
+    si <- seqinfo(covg)
+    seqlengths(si) <- sapply(covg, length)
+    new_contigs <- attr(find_spike_contigs(covg, spike), "mapping")
+    spike_gr <- as(si, "GRanges")
+    names(spike_gr) <- new_contigs[names(spike_gr)]
+  }
   canon <- names(spike_gr)
 
   message("Summarizing spike-in counts...", appendLF=FALSE)

--- a/man/get_spike_depth.Rd
+++ b/man/get_spike_depth.Rd
@@ -4,12 +4,12 @@
 \alias{get_spike_depth}
 \title{get the (max, median, or mean) coverage for spike-in contigs from a BAM/CRAM}
 \usage{
-get_spike_depth(covg, spike_gr, spike, how = c("max", "mean"))
+get_spike_depth(covg, spike_gr = NULL, spike = NULL, how = c("max", "mean"))
 }
 \arguments{
 \item{covg}{the coverage RleList}
 
-\item{spike_gr}{the spike-in GRanges}
+\item{spike_gr}{the spike-in GRanges (default: figure out from seqinfo)}
 
 \item{spike}{information about the spikes (default: load \code{spike})}
 

--- a/man/scan_genomic_contigs.Rd
+++ b/man/scan_genomic_contigs.Rd
@@ -7,7 +7,7 @@
 scan_genomic_contigs(bam, spike, param = NULL, ...)
 }
 \arguments{
-\item{bam}{the BAM or CRAM file}
+\item{bam}{the BAM or CRAM filename, or a vector of them}
 
 \item{spike}{the spike-in reference database (e.g. data(spike))}
 
@@ -34,6 +34,9 @@ that anything which isn't a spike contig, is a genomic contig.  This isn't
 necessarily true, so the user can also supply a ScanBamParam object for the
 \code{param} argument and restrict scanning to whatever contigs they wish, which
 also allows for non-default MAPQ, pairing, and quality filters.
+
+If multiple BAM or CRAM filenames are provided, all indices will be
+checked before attempting to run through any of the files.
 }
 \examples{
 

--- a/man/scan_spike_contigs.Rd
+++ b/man/scan_spike_contigs.Rd
@@ -7,7 +7,7 @@
 scan_spike_contigs(bam, spike, param = NULL, ...)
 }
 \arguments{
-\item{bam}{the BAM or CRAM file}
+\item{bam}{the BAM or CRAM filename, or a vector of such filenames}
 
 \item{spike}{the spike-in reference database (e.g. data(spike))}
 
@@ -31,8 +31,8 @@ default workflow is
 
 scan_spike_contigs implements step 1.
 
-add CRAM example here -- tested & works with reheadered spike CRAMs.
-Slower than one might like however.
+If multiple BAM or CRAM filenames are provided, all indices will be
+checked before attempting to run through any of the files.
 }
 \examples{
 library(GenomicRanges)


### PR DESCRIPTION
Mostly internal checks for whether objects have the appropriate structure and payloads, along with length-based lapply usage